### PR TITLE
Update Defmt to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ name = "defmt-rtt-target"
 version = "0.1.0"
 
 [dependencies]
-defmt = "0.1.0"
+defmt = "0.3.0"
 cortex-m = "0.6.3"
-rtt-target = "0.2.2"
+rtt-target = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 
-use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, Ordering};
 use cortex_m::{interrupt, register};
 use rtt_target::UpChannel;
@@ -12,48 +11,52 @@ static mut CHANNEL: Option<UpChannel> = None;
 #[defmt::global_logger]
 struct Logger;
 
-impl defmt::Write for Logger {
-    fn write(&mut self, bytes: &[u8]) {
-        unsafe {
-            if let Some(c) = &mut CHANNEL {
-                c.write(bytes);
-            }
-        };
-    }
-}
-
 pub fn init(channel: UpChannel) {
     unsafe { CHANNEL = Some(channel) }
 }
 
 static TAKEN: AtomicBool = AtomicBool::new(false);
 static INTERRUPTS_ACTIVE: AtomicBool = AtomicBool::new(false);
+static mut ENCODER: defmt::Encoder = defmt::Encoder::new();
 
 unsafe impl defmt::Logger for Logger {
-    fn acquire() -> Option<NonNull<dyn defmt::Write>> {
+    fn acquire() {
         let primask = register::primask::read();
         interrupt::disable();
-        if !TAKEN.load(Ordering::Relaxed) {
-            // no need for CAS because interrupts are disabled
-            TAKEN.store(true, Ordering::Relaxed);
 
-            INTERRUPTS_ACTIVE.store(primask.is_active(), Ordering::Relaxed);
-
-            Some(NonNull::from(&Logger as &dyn defmt::Write))
-        } else {
-            if primask.is_active() {
-                // re-enable interrupts
-                unsafe { interrupt::enable() }
-            }
-            None
+        if TAKEN.load(Ordering::Relaxed) {
+            panic!("defmt logger taken reentrantly")
         }
+
+        // no need for CAS because interrupts are disabled
+        TAKEN.store(true, Ordering::Relaxed);
+
+        INTERRUPTS_ACTIVE.store(primask.is_active(), Ordering::Relaxed);
+
+        unsafe { ENCODER.start_frame(do_write) }
     }
 
-    unsafe fn release(_: NonNull<dyn defmt::Write>) {
+    unsafe fn release() {
+        ENCODER.end_frame(do_write);
+
         TAKEN.store(false, Ordering::Relaxed);
         if INTERRUPTS_ACTIVE.load(Ordering::Relaxed) {
             // re-enable interrupts
             interrupt::enable()
+        }
+    }
+
+    unsafe fn flush() {}
+
+    unsafe fn write(bytes: &[u8]) {
+        ENCODER.write(bytes, do_write);
+    }
+}
+
+fn do_write(bytes: &[u8]) {
+    unsafe {
+        if let Some(c) = &mut CHANNEL {
+            c.write(bytes);
         }
     }
 }


### PR DESCRIPTION
Changes based on [defmt migration doc](https://defmt.ferrous-systems.com/migration-02-03.html#adapt-manual-trait-logger-implementations) and defmt-rtt code.

I feel it shouldn't be too complicated to implement flush, but it requires an update for `rtt-target::UpChannel` exposing a helper for it.